### PR TITLE
Added my simple but nice panel

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6599,6 +6599,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "walshydev-uptime-panel",
+      "type": "panel",
+      "url": "https://github.com/WalshyDev/Uptime-Panel",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "88d8a509ab31ba4f65368a2a890fbb4b398f930e",
+          "url": "https://github.com/WalshyDev/Uptime-Panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/WalshyDev/Uptime-Panel/releases/download/v0.1.0/walshydev-uptime-0.1.0.zip",
+              "md5": "0d165e56cbc493d39eac425fa8bed7c1"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -6606,13 +6606,13 @@
       "url": "https://github.com/WalshyDev/Uptime-Panel",
       "versions": [
         {
-          "version": "1.0.0",
-          "commit": "88d8a509ab31ba4f65368a2a890fbb4b398f930e",
+          "version": "0.1.0",
+          "commit": "23279fad9b04e740d0aed6e94dac7de93bd64085",
           "url": "https://github.com/WalshyDev/Uptime-Panel",
           "download": {
             "any": {
               "url": "https://github.com/WalshyDev/Uptime-Panel/releases/download/v0.1.0/walshydev-uptime-0.1.0.zip",
-              "md5": "0d165e56cbc493d39eac425fa8bed7c1"
+              "md5": "3f440036be82148d388bef314a774209"
             }
           }
         }


### PR DESCRIPTION
Hey Grafana team!

I wish to publish my simple but nice panel, it is used to simply display how long since a unix timestamp. This can be used for seeing how long a service/application is up or just seeing how long since a given time.

Examples:
![image](https://user-images.githubusercontent.com/8492901/122573963-0d571b80-d047-11eb-9e78-8bc198214205.png)
![image](https://user-images.githubusercontent.com/8492901/122573992-1647ed00-d047-11eb-8e5a-2ec65733e864.png)

My [README](https://github.com/WalshyDev/Uptime-Panel/blob/main/README.md) should describe everything.

---

This is currently unsigned as it's my first release, if this could get the `Community` level that would be great! Once I can sign I will release a new update and update here.